### PR TITLE
Update scecli-1202-events.md

### DIFF
--- a/support/windows-server/group-policy/scecli-1202-events.md
+++ b/support/windows-server/group-policy/scecli-1202-events.md
@@ -54,7 +54,10 @@ To troubleshoot this issue, follow these steps:
 2. Refresh the policy settings to reproduce the failure. To refresh the policy settings, type the following command at the command prompt, and then press ENTER:
 
     ```console
-    secedit /refreshpolicy machine_policy /enforce
+    the deprecated command 
+    **secedit /refreshpolicy machine_policy /enforce**
+    as been replaced by 
+    **GPUPDATE **
     ```
 
     This command creates a file that is named *Winlogon.log* in the `%SYSTEMROOT%\Security\Logs` folder.
@@ -142,7 +145,10 @@ To troubleshoot this issue, follow these steps:
 2. Refresh the policy settings to reproduce the failure. To refresh the policy settings, type the following command at the command prompt, and then press ENTER:
 
     ```console
-    secedit /refreshpolicy machine_policy /enforce
+    the deprecated command 
+    **secedit /refreshpolicy machine_policy /enforce**
+    as been replaced by 
+    **GPUPDATE **
     ```
 
     This command creates a file that's named *Winlogon.log* in the `%SYSTEMROOT%\Security\Logs` folder.


### PR DESCRIPTION
the deprecated command 
    **secedit /refreshpolicy machine_policy /enforce**
    as been replaced by 
    **GPUPDATE **